### PR TITLE
Provide a Transcript RNG which generalizes synthetic nonce creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ features = ["nightly"]
 keccak = "0.1.0"
 byteorder = "1.2.4"
 clear_on_drop = "0.2.3"
+rand_core = "0.2"
+rand = "0.5"
 
 [dev-dependencies]
 strobe-rs = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,11 @@ impl TranscriptRngConstructor {
     ///
     /// The `label` parameter is metadata about the witness, and is
     /// also committed to the transcript.
-    pub fn commit_witness(mut self, label: &[u8], witness: &[u8]) -> TranscriptRngConstructor {
+    pub fn commit_witness_bytes(
+        mut self,
+        label: &[u8],
+        witness: &[u8],
+    ) -> TranscriptRngConstructor {
         let witness_len = encode_usize(witness.len());
         self.strobe.meta_ad(label, false);
         self.strobe.meta_ad(&witness_len, true);
@@ -200,7 +204,7 @@ impl TranscriptRngConstructor {
             bytes
         };
 
-        self.commit_witness(b"rng", &random_bytes)
+        self.commit_witness_bytes(b"rng", &random_bytes)
     }
 
     pub fn finalize(self) -> TranscriptRng {
@@ -371,25 +375,25 @@ mod tests {
 
         let mut r1 = t1
             .fork_transcript()
-            .commit_witness(b"witness", witness1)
+            .commit_witness_bytes(b"witness", witness1)
             .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
             .finalize();
 
         let mut r2 = t2
             .fork_transcript()
-            .commit_witness(b"witness", witness1)
+            .commit_witness_bytes(b"witness", witness1)
             .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
             .finalize();
 
         let mut r3 = t3
             .fork_transcript()
-            .commit_witness(b"witness", witness2)
+            .commit_witness_bytes(b"witness", witness2)
             .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
             .finalize();
 
         let mut r4 = t4
             .fork_transcript()
-            .commit_witness(b"witness", witness2)
+            .commit_witness_bytes(b"witness", witness2)
             .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
             .finalize();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,13 @@ impl Transcript {
     }
 }
 
-/// The prover can commit secrets or randomness to the
-/// `TranscriptRngConstructor` before finalizing to obtain a
-/// `TranscriptRng` which is a PRF of the entire transcript as well as
-/// the prover's secrets and randomness.
+/// The prover can commit witness data to the
+/// `TranscriptRngConstructor` before using an external RNG to
+/// finalize to a `TranscriptRng`.
+///
+/// The resulting `TranscriptRng` will be a PRF of the entire public
+/// transcript, as well as of the prover's witness data, as well as of
+/// randomness from the external RNG.
 ///
 /// See the `TranscriptRng` documentation for more details.
 pub struct TranscriptRngConstructor {
@@ -169,11 +172,9 @@ pub struct TranscriptRngConstructor {
 }
 
 impl TranscriptRngConstructor {
-    /// Commit witness data to the transcript, so that the finalized
-    /// `TranscriptRng` is a PRF bound to `witness` as well as all
-    /// other transcript data.
+    /// Rekey the transcript using the provided witness data.
     ///
-    /// The `label` parameter is metadata about the witness, and is
+    /// The `label` parameter is metadata about `witness`, and is
     /// also committed to the transcript.
     pub fn commit_witness_bytes(
         mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,15 +215,6 @@ pub struct TranscriptRng {
     strobe: Strobe128,
 }
 
-impl TranscriptRng {
-    pub fn labeled_fill_bytes(&mut self, label: &[u8], dest: &mut [u8]) {
-        let dest_len = encode_usize(dest.len());
-        self.strobe.meta_ad(label, false);
-        self.strobe.meta_ad(&dest_len, true);
-        self.strobe.prf(dest, false);
-    }
-}
-
 impl rand_core::RngCore for TranscriptRng {
     fn next_u32(&mut self) -> u32 {
         rand_core::impls::next_u32_via_fill(self)
@@ -234,9 +225,9 @@ impl rand_core::RngCore for TranscriptRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        // When using the TranscriptRng as a rand::Rng instance, we
-        // don't get to set the label, so just use an empty one.
-        self.labeled_fill_bytes(b"", dest);
+        let dest_len = encode_usize(dest.len());
+        self.strobe.meta_ad(&dest_len, false);
+        self.strobe.prf(dest, false);
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,11 @@ extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;
 extern crate keccak;
+extern crate rand;
+extern crate rand_core;
 
+#[cfg(test)]
+extern crate curve25519_dalek;
 #[cfg(test)]
 extern crate strobe_rs;
 
@@ -142,7 +146,104 @@ impl Transcript {
         self.strobe.meta_ad(&data_len, true);
         self.strobe.prf(dest, false);
     }
+
+    /// Fork the current `Transcript` to construct an RNG whose output is bound
+    /// to the current transcript state as well as prover's secrets.
+    ///
+    /// See the `TranscriptRng` documentation for more details.
+    pub fn fork_transcript(&self) -> TranscriptRngConstructor {
+        TranscriptRngConstructor {
+            strobe: self.strobe.clone(),
+        }
+    }
 }
+
+/// The prover can commit secrets or randomness to the
+/// `TranscriptRngConstructor` before finalizing to obtain a
+/// `TranscriptRng` which is a PRF of the entire transcript as well as
+/// the prover's secrets and randomness.
+///
+/// See the `TranscriptRng` documentation for more details.
+pub struct TranscriptRngConstructor {
+    strobe: Strobe128,
+}
+
+impl TranscriptRngConstructor {
+    /// Commit witness data to the transcript, so that the finalized
+    /// `TranscriptRng` is a PRF bound to `witness` as well as all
+    /// other transcript data.
+    ///
+    /// The `label` parameter is metadata about the witness, and is
+    /// also committed to the transcript.
+    pub fn commit_witness(mut self, label: &[u8], witness: &[u8]) -> TranscriptRngConstructor {
+        let witness_len = encode_usize(witness.len());
+        self.strobe.meta_ad(label, false);
+        self.strobe.meta_ad(&witness_len, true);
+        self.strobe.key(witness, false);
+
+        self
+    }
+
+    /// Use the supplied `rng` to rekey the transcript, so that the
+    /// finalized `TranscriptRng` is a PRF bound to randomness from
+    /// the external RNG, as well as all other transcript data.
+    ///
+    /// The input from the auxiliary RNG is modeled as an additional
+    /// witness variable, and committed using `commit_witness`.
+    pub fn rekey_rng<R>(self, rng: &mut R) -> TranscriptRngConstructor
+    where
+        R: rand::Rng + rand::CryptoRng,
+    {
+        let random_bytes = {
+            let mut bytes = [0u8; 32];
+            rng.fill(&mut bytes);
+            bytes
+        };
+
+        self.commit_witness(b"rng", &random_bytes)
+    }
+
+    pub fn finalize(self) -> TranscriptRng {
+        TranscriptRng {
+            strobe: self.strobe,
+        }
+    }
+}
+
+pub struct TranscriptRng {
+    strobe: Strobe128,
+}
+
+impl TranscriptRng {
+    pub fn labeled_fill_bytes(&mut self, label: &[u8], dest: &mut [u8]) {
+        let dest_len = encode_usize(dest.len());
+        self.strobe.meta_ad(label, false);
+        self.strobe.meta_ad(&dest_len, true);
+        self.strobe.prf(dest, false);
+    }
+}
+
+impl rand_core::RngCore for TranscriptRng {
+    fn next_u32(&mut self) -> u32 {
+        rand_core::impls::next_u32_via_fill(self)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        rand_core::impls::next_u64_via_fill(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        // When using the TranscriptRng as a rand::Rng instance, we
+        // don't get to set the label, so just use a fixed one
+        self.labeled_fill_bytes(b"rng", dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        Ok(self.fill_bytes(dest))
+    }
+}
+
+impl rand::CryptoRng for TranscriptRng {}
 
 #[cfg(test)]
 mod tests {
@@ -239,5 +340,80 @@ mod tests {
             real_transcript.commit_bytes(b"challengedata", &real_challenge);
             test_transcript.commit_bytes(b"challengedata", &test_challenge);
         }
+    }
+
+    #[test]
+    fn transcript_rng_is_bound_to_transcript_and_witnesses() {
+        use curve25519_dalek::scalar::Scalar;
+        use rand::prng::chacha::ChaChaRng;
+        use rand::SeedableRng;
+
+        // Check that the TranscriptRng is bound to the transcript and
+        // the witnesses.  This is done by producing a sequence of
+        // transcripts that diverge at different points and checking
+        // that they produce different challenges.
+
+        let protocol_label = b"test TranscriptRng collisions";
+        let commitment1 = b"commitment data 1";
+        let commitment2 = b"commitment data 2";
+        let witness1 = b"witness data 1";
+        let witness2 = b"witness data 2";
+
+        let mut t1 = Transcript::new(protocol_label);
+        let mut t2 = Transcript::new(protocol_label);
+        let mut t3 = Transcript::new(protocol_label);
+        let mut t4 = Transcript::new(protocol_label);
+
+        t1.commit_bytes(b"com", commitment1);
+        t2.commit_bytes(b"com", commitment2);
+        t3.commit_bytes(b"com", commitment2);
+        t4.commit_bytes(b"com", commitment2);
+
+        let mut r1 = t1
+            .fork_transcript()
+            .commit_witness(b"witness", witness1)
+            .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
+            .finalize();
+
+        let mut r2 = t2
+            .fork_transcript()
+            .commit_witness(b"witness", witness1)
+            .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
+            .finalize();
+
+        let mut r3 = t3
+            .fork_transcript()
+            .commit_witness(b"witness", witness2)
+            .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
+            .finalize();
+
+        let mut r4 = t4
+            .fork_transcript()
+            .commit_witness(b"witness", witness2)
+            .rekey_rng(&mut ChaChaRng::from_seed([0; 32]))
+            .finalize();
+
+        let s1 = Scalar::random(&mut r1);
+        let s2 = Scalar::random(&mut r2);
+        let s3 = Scalar::random(&mut r3);
+        let s4 = Scalar::random(&mut r4);
+
+        // Transcript t1 has different commitments than t2, t3, t4, so
+        // it should produce distinct challenges from all of them.
+        assert_ne!(s1, s2);
+        assert_ne!(s1, s3);
+        assert_ne!(s1, s4);
+
+        // Transcript t2 has different witness variables from t3, t4,
+        // so it should produce distinct challenges from all of them.
+        assert_ne!(s2, s3);
+        assert_ne!(s2, s4);
+
+        // Transcripts t3 and t4 have the same commitments and
+        // witnesses, so they should give different challenges only
+        // based on the RNG. Checking that they're equal in the
+        // presence of a bad RNG checks that the different challenges
+        // above aren't because the RNG is accidentally different.
+        assert_eq!(s3, s4);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,8 @@ impl rand_core::RngCore for TranscriptRng {
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         // When using the TranscriptRng as a rand::Rng instance, we
-        // don't get to set the label, so just use a fixed one
-        self.labeled_fill_bytes(b"rng", dest);
+        // don't get to set the label, so just use an empty one.
+        self.labeled_fill_bytes(b"", dest);
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -78,7 +78,7 @@ impl Strobe128 {
 
     pub fn key(&mut self, data: &[u8], more: bool) {
         self.begin_op(FLAG_A | FLAG_C, more);
-        self.overwrite(data, false);
+        self.overwrite(data);
     }
 }
 


### PR DESCRIPTION
This is a sketch of a design for a STROBE-based RNG for use by the prover to generate blinding factors, etc.  It's intended to generalize from 

1.  the deterministic nonce generation in Ed25519 & RFC 6979;
2.  Trevor Perrin's ["synthetic" nonce generation for Generalised EdDSA](https://moderncrypto.org/mail-archive/curves/2017/000925.html);
3.  and Mike Hamburg's nonce generation mechanism sketched in the [STROBE paper](https://strobe.sourceforge.io/papers/strobe-20170130.pdf);

towards a design that's flexible enough for arbitrarily complex public-coin arguments.

## Deterministic and synthetic generation of blinding factors

In Schnorr signatures (the context for the above designs), the "nonce" is really a blinding factor used for a single sigma-protocol (a proof of knowledge of the secret key, with the message in the context); in a more complex protocol like Bulletproofs, the prover runs a bunch of sigma protocols in sequence and needs a bunch of blinding factors for each of them.

As noted in Trevor's mail, bad randomness in the blinding factor can screw up Schnorr signatures in lots of ways:

* guessing the blinding reveals the secret;
* using the same blinding for two proofs reveals the secret;
* leaking a few bits of each blinding factor over many proofs can allow recovery of the secret.

For more complex ZK arguments there's probably lots of even more horrible ways that everything can go wrong, so it would be good to **design a comprehensive fix that applies to Merlin's setting**.

In (1), the blinding factor is generated as the hash of both the message data and a secret key unique to each signer, so that the blinding factors are generated in a deterministic but secret way, avoiding problems with bad randomness.  However, the choice to make the blinding factors fully deterministic makes fault injection attacks much easier, which has been used with some success on Ed25519.

In (2), the blinding factor is generated as the hash of all of the message data, some secret key, and some randomness from an external RNG. This retains the benefits of (1), but without the disadvantages of being fully deterministic.

The STROBE paper (3) describes a variant of (1) for performing STROBE-based Schnorr signatures, where the blinding factor is generated in the following way: first, the STROBE context is copied; then, the signer uses a private key `k` to perform the STROBE operations
```
KEY[sym-key](k); 
r <- PRF[sig-determ]()
```

The STROBE design is nice because forking the transcript exactly when randomness is required ensures that, if the transcripts are different, the blinding factor will be different -- no matter how much extra data was fed into the transcript.  This means that even though it's deterministic, it's automatically protected against an issue Trevor mentioned:

>  (2) Without randomization, the algorithm is fragile to modifications and misuse.  In particular, modifying it to add an extra input to h=... without also adding the input to r=... would leak the private scalar if the same message is signed with a different extra input.  So would signing a message twice, once passing in an incorrect public key K (though the synthetic-nonce algorithm fixes this separately by hashing K into r).

## Goals

We should provide an API that allows Merlin users to generate randomness which is derived from both the transcript state, prover secrets, and the output of an external RNG, to combine (2) and (3).

In the Merlin setting, the only secrets available to the prover are the witness variables for the proof statement. This means that in the presence of a weak or failing RNG, the "backup" entropy is limited to the entropy of the witness variables. This isn't ideal, since the witnesses may be low-entropy (for instance in the case of a range proof) but I'm not sure what else there is to do.

## API Sketch

This API is intended to allow the following:
```rust
        let mut rng = transcript
            .fork_transcript() // -> TranscriptRngConstructor
            .commit_witness_bytes(b"witness", witness_data)
            .reseed_from_rng(&mut rand::thread_rng()); // -> TranscriptRng
        let s = Scalar::random(&mut rng);
```
The method names could be changed, but the workflow is as follows: at any point, the prover can fork the internal STROBE state into a `TranscriptRngConstructor`.

The prover then runs `TranscriptRngConstructor::commit_witness_bytes()`, which performs `KEY[label](key)`. After committing any relevant witness data, the prover runs `TranscriptRngConstructor::reseed_from_rng()`, which extracts 32 bytes of randomness from the external RNG and performs `KEY["rng"](random_bytes)`. This consumes the `TranscriptRngConstructor` to produce a `TranscriptRng`, which implements the `rand::{Rng, CryptoRng}` traits.

This design uses the type system to ensure that the prover must commit to witness data before it can request randomness, preventing the prover from accidentally forgetting to rekey the STROBE state.

The API uses method chaining. This is intended to encourage API consumers to fork the transcript and rekey at each stage that they need randomness, by making it easy to get the final RNG without having to create a bunch of intermediate variables. By forcing ownership to pass along the method chain, it also makes the prover-specific code with witness commitments operate differently than the prover-and-verifier-common transcript operations.

Thanks to @isislovecruft for the design discussions.