### PR TITLE
Remove unsafe transmutes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,15 @@
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
+#[cfg(target_endian = "big")]
+compile_error!(
+    r#"
+This crate doesn't support big-endian targets, since I didn't
+have one to test correctness on.  If you're seeing this message,
+please file an issue!
+"#
+);
+
 extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -12,6 +12,10 @@ const FLAG_T: u8 = 1 << 3;
 const FLAG_M: u8 = 1 << 4;
 const FLAG_K: u8 = 1 << 5;
 
+fn transmute_state(st: &mut [u8; 200]) -> &mut [u64; 25] {
+    unsafe { &mut *(st as *mut [u8; 200] as *mut [u64; 25]) }
+}
+
 /// A Strobe context for the 128-bit security level.
 ///
 /// Only `meta-AD`, `AD`, `KEY`, and `PRF` operations are supported.
@@ -44,7 +48,7 @@ impl Strobe128 {
             let mut st = [0u8; 200];
             st[0..6].copy_from_slice(&[1, STROBE_R + 2, 1, 0, 1, 96]);
             st[6..18].copy_from_slice(b"STROBEv1.0.2");
-            keccak::f1600(unsafe { ::std::mem::transmute(&mut st) });
+            keccak::f1600(transmute_state(&mut st));
 
             st
         };
@@ -87,7 +91,7 @@ impl Strobe128 {
         self.state[self.pos as usize] ^= self.pos_begin;
         self.state[(self.pos + 1) as usize] ^= 0x04;
         self.state[(STROBE_R + 1) as usize] ^= 0x80;
-        keccak::f1600(unsafe { ::std::mem::transmute(&mut self.state) });
+        keccak::f1600(transmute_state(&mut self.state));
         self.pos = 0;
         self.pos_begin = 0;
     }


### PR DESCRIPTION
So far this is better than it was before, but it's still unsafe, because of different alignment requirements on the pointers.

Unfortunately keeping the state as a `[u64; 25]` seems like it wouldn't really work.  If the state is stored as bytes, then converting to words to run `keccakf` may require a byteswap on BE. But if the state is stored as words, then accessing it as bytes will always require a byteswap, and we do that way more often.