### PR TITLE
docs: clarify protocol version vs API version

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,7 @@
 /// Domain separation label to initialize the STROBE context.
 ///
-/// This should be consistent with the crate's semver string.
+/// This is not to be confused with the crate's semver string:
+/// the latter applies to the API, while this label defines the protocol.
+/// E.g. it is possible that crate 2.0 will have an incompatible API,
+/// but implement the same 1.0 protocol.
 pub const MERLIN_PROTOCOL_LABEL: &[u8] = b"Merlin v1.0";


### PR DESCRIPTION
The "Merlin v1.0" label domain-separates incompatible _protocols_, while the crate semver applies also to the API. So it is conceivable that Merlin-the-crate may decide to implement an incompatible API (v2.0 crate) while being compatible with the same Merlin-the-protocol (v1.0 protocol and label).