### PR TITLE
Add a debug feature to the Transcript code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ byteorder = "1.2.4"
 clear_on_drop = "0.2.3"
 rand_core = "0.3"
 rand = "0.6"
+hex = {version = "0.3", optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.3"
@@ -31,3 +32,4 @@ rand_chacha = "0.1"
 
 [features]
 nightly = ["clear_on_drop/nightly"]
+debug-transcript = ["hex"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ for use by the prover.  This provides synthetic randomness derived from
 the entire public transcript, as well as the prover's witness data,
 and an auxiliary input from an external RNG.
 
+## Features
+
+The `nightly` feature is passed to `clear_on_drop`; it may be replaced
+with a no-op in the future (since `clear_on_drop` is an implementation
+detail).
+
+The `debug-transcript` feature prints an annotated proof transcript to
+`stdout`; it is only suitable for development and testing purposes,
+should not be used in released crates, and should not be considered stable.
+
 ## About
 
 Merlin is authored by Henry de Valence, with design input from Isis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ extern crate rand_core;
 
 #[cfg(test)]
 extern crate curve25519_dalek;
+#[cfg(feature = "hex")]
+extern crate hex;
 #[cfg(test)]
 extern crate rand_chacha;
 #[cfg(test)]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -150,6 +150,16 @@ impl Transcript {
     pub fn new(label: &'static [u8]) -> Transcript {
         use constants::MERLIN_PROTOCOL_LABEL;
 
+        #[cfg(feature = "debug-transcript")]
+        {
+            use std::str::from_utf8;
+            println!(
+                "Initialize STROBE-128({})\t# b\"{}\"",
+                hex::encode(MERLIN_PROTOCOL_LABEL),
+                from_utf8(MERLIN_PROTOCOL_LABEL).unwrap(),
+            );
+        }
+
         let mut transcript = Transcript {
             strobe: Strobe128::new(MERLIN_PROTOCOL_LABEL),
         };
@@ -175,6 +185,37 @@ impl Transcript {
         self.strobe.meta_ad(label, false);
         self.strobe.meta_ad(&data_len, true);
         self.strobe.ad(message, false);
+
+        #[cfg(feature = "debug-transcript")]
+        {
+            use std::str::from_utf8;
+
+            match from_utf8(label) {
+                Ok(label_str) => {
+                    println!(
+                        "meta-AD : {} || LE32({})\t# b\"{}\"",
+                        hex::encode(label),
+                        message.len(),
+                        label_str
+                    );
+                }
+                Err(_) => {
+                    println!(
+                        "meta-AD : {} || LE32({})",
+                        hex::encode(label),
+                        message.len()
+                    );
+                }
+            }
+            match from_utf8(message) {
+                Ok(message_str) => {
+                    println!("     AD : {}\t# b\"{}\"", hex::encode(message), message_str);
+                }
+                Err(_) => {
+                    println!("     AD : {}", hex::encode(message));
+                }
+            }
+        }
     }
 
     /// Convenience method for committing a `u64` to the transcript.
@@ -206,6 +247,26 @@ impl Transcript {
         self.strobe.meta_ad(label, false);
         self.strobe.meta_ad(&data_len, true);
         self.strobe.prf(dest, false);
+
+        #[cfg(feature = "debug-transcript")]
+        {
+            use std::str::from_utf8;
+
+            match from_utf8(label) {
+                Ok(label_str) => {
+                    println!(
+                        "meta-AD : {} || LE32({})\t# b\"{}\"",
+                        hex::encode(label),
+                        dest.len(),
+                        label_str
+                    );
+                }
+                Err(_) => {
+                    println!("meta-AD : {} || LE32({})", hex::encode(label), dest.len());
+                }
+            }
+            println!("     PRF: {}", hex::encode(dest));
+        }
     }
 
     /// Fork the current [`Transcript`] to construct an RNG whose output is bound


### PR DESCRIPTION
This allows pretty-printing a run of a Merlin transcript.

Example: https://gist.github.com/hdevalence/9db3997cc275597eeae1ec2461b8e2a1