### PR TITLE
Remove `rand` dependency in favor of `rand_core`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ keccak = "0.1.0"
 byteorder = "1.2.4"
 clear_on_drop = "0.2.3"
 rand_core = "0.3"
-rand = "0.6"
 hex = {version = "0.3", optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.3"
 curve25519-dalek = "1"
 rand_chacha = "0.1"
+rand = "0.6"
 
 [features]
 nightly = ["clear_on_drop/nightly"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bound to the statements to be proved;
 
 * and protocol composition, by using a common transcript for multiple protocols.
 
-In addition, Merlin provides a transcript-based `rand::Rng` instance
+In addition, Merlin provides a transcript-based `rand_core::RngCore` instance
 for use by the prover.  This provides synthetic randomness derived from
 the entire public transcript, as well as the prover's witness data,
 and an auxiliary input from an external RNG.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,14 @@ extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;
 extern crate keccak;
-extern crate rand;
 extern crate rand_core;
 
 #[cfg(test)]
 extern crate curve25519_dalek;
 #[cfg(feature = "hex")]
 extern crate hex;
+#[cfg(test)]
+extern crate rand;
 #[cfg(test)]
 extern crate rand_chacha;
 #[cfg(test)]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,4 +1,3 @@
-use rand;
 use rand_core;
 
 use strobe::Strobe128;
@@ -292,12 +291,12 @@ impl Transcript {
 /// # Usage
 ///
 /// To construct a [`TranscriptRng`], a prover calls
-/// [`Transcript::build_rng()`] to clone the transcript state,
-/// then uses [`commit_witness_bytes()`][commit_witness_bytes] to
-/// rekey the transcript with the prover's secrets, before finally
-/// calling [`finalize()`][finalize].  This rekeys the
-/// transcript with the output of an external [`rand::Rng`] instance
-/// and returns a finalized [`TranscriptRng`].
+/// [`Transcript::build_rng()`] to clone the transcript state, then
+/// uses [`commit_witness_bytes()`][commit_witness_bytes] to rekey the
+/// transcript with the prover's secrets, before finally calling
+/// [`finalize()`][finalize].  This rekeys the transcript with the
+/// output of an external [`rand_core::RngCore`] instance and returns
+/// a finalized [`TranscriptRng`].
 ///
 /// These methods are intended to be chained, passing from a borrowed
 /// [`Transcript`] to an owned [`TranscriptRng`] as follows:
@@ -391,11 +390,11 @@ impl TranscriptRngBuilder {
     /// ```
     pub fn finalize<R>(mut self, rng: &mut R) -> TranscriptRng
     where
-        R: rand::Rng + rand::CryptoRng,
+        R: rand_core::RngCore + rand_core::CryptoRng,
     {
         let random_bytes = {
             let mut bytes = [0u8; 32];
-            rng.fill(&mut bytes);
+            rng.fill_bytes(&mut bytes);
             bytes
         };
 
@@ -502,7 +501,7 @@ impl TranscriptRngBuilder {
 /// [`TranscriptRngBuilder`], which allows the prover to rekey the
 /// STROBE state with arbitrary witness data, and then forces the
 /// prover to rekey the STROBE state with the output of an external
-/// [`rand::Rng`] instance.  The [`TranscriptRng`] then uses STROBE
+/// [`rand_core::RngCore`] instance.  The [`TranscriptRng`] then uses STROBE
 /// `PRF` operations to provide randomness.
 ///
 /// Binding the output to the [`Transcript`] state ensures that two
@@ -540,7 +539,7 @@ impl rand_core::RngCore for TranscriptRng {
     }
 }
 
-impl rand::CryptoRng for TranscriptRng {}
+impl rand_core::CryptoRng for TranscriptRng {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This should be semver-compatible for the same reasons as in curve25519-dalek.