### PR TITLE
Derive PartialEq, Eq, PartialOrd, Ord, and Hash

### DIFF
--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -27,7 +27,7 @@ struct AlignedKeccakState([u8; 200]);
 /// A Strobe context for the 128-bit security level.
 ///
 /// Only `meta-AD`, `AD`, `KEY`, and `PRF` operations are supported.
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Strobe128 {
     state: AlignedKeccakState,
     pos: u8,
@@ -179,6 +179,32 @@ impl Deref for AlignedKeccakState {
 impl DerefMut for AlignedKeccakState {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl PartialEq<Self> for AlignedKeccakState {
+    fn eq(&self, other: &Self) -> bool {
+        (&self.0[..]).eq(&other.0[..])
+    }
+}
+
+impl Eq for AlignedKeccakState {}
+
+impl PartialOrd<Self> for AlignedKeccakState {
+    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+        (&self.0[..]).partial_cmp(&other.0[..])
+    }
+}
+
+impl Ord for AlignedKeccakState {
+    fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+        (&self.0[..]).cmp(&other.0[..])
+    }
+}
+
+impl ::core::hash::Hash for AlignedKeccakState {
+    fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
+        (&self.0[..]).hash(state)
     }
 }
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -123,7 +123,7 @@ fn encode_usize_as_u32(x: usize) -> [u8; 4] {
 /// However, because the protocol-specific behaviour is defined in a
 /// protocol-specific trait, different protocols can use the same
 /// [`Transcript`] instance without imposing any extra type constraints.
-#[derive(Clone)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Transcript {
     strobe: Strobe128,
 }


### PR DESCRIPTION
These traits permit using a `Transcript` as a key in a HashMap or BTreeMap, which permits handy optimizations, such as in conjunction with pairings.  These do leak state to the caller of course, but if that's a concern then they could operate on only the first 32-64 bytes of the state.. or `Hash` could include its own siphasher invocation, and the others could be ignored.  It's a nice feature of strobe that the state contains almost only the 200 byte keccak state, so siphash can usually process it faster than ant relevant from which the `Transcript` was created. 