### PR TITLE
Fix no_std and add Travis testing for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 cache: cargo
 
-
 matrix:
   include:
   - rust: stable
@@ -13,6 +12,14 @@ matrix:
     script:
     - cargo test
     - cargo fmt --all -- --check
+  # Test if crate can be truly built without std
+  - rust: nightly
+    env: TARGET=thumbv7em-none-eabi
+    script: xargo build --no-default-features --features="nightly" --target $TARGET
+    install:
+      - cargo install xargo || true
+      - rustup target install armv7-unknown-linux-gnueabihf
+      - rustup component add rust-src
 
 notifications:
   slack:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ exclude = [".travis.yml", ".gitignore"]
 features = ["nightly"]
 
 [dependencies]
-keccak = "0.1.0"
-byteorder = "1.2.4"
-clear_on_drop = "0.2.3"
-rand_core = "0.3"
-hex = {version = "0.3", optional = true}
+keccak = { version = "0.1.0", default-features = false }
+byteorder = { version = "1.2.4", default-features = false }
+clear_on_drop = { version = "0.2.3", default-features = false }
+rand_core = { version = "0.3", default-features = false }
+hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.3"
@@ -31,5 +31,8 @@ rand_chacha = "0.1"
 rand = "0.6"
 
 [features]
+default = ["std"]
 nightly = ["clear_on_drop/nightly"]
 debug-transcript = ["hex"]
+std = ["rand_core/std", "byteorder/std"]
+alloc = ["rand_core/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ rand_core = { version = "0.3", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
-strobe-rs = "0.3"
-curve25519-dalek = "1"
-rand_chacha = "0.1"
-rand = "0.6"
+strobe-rs = { version = "0.3", default-features = false }
+curve25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
+rand_chacha = { version = "0.1", default-features = false }
+rand = { version = "0.6", default-features = false }
 
 [features]
 default = ["std"]
 nightly = ["clear_on_drop/nightly"]
 debug-transcript = ["hex"]
-std = ["rand_core/std", "byteorder/std"]
-alloc = ["rand_core/alloc"]
+std = ["rand_core/std", "rand/std", "byteorder/std"]
+alloc = ["rand_core/alloc", "rand/alloc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
@@ -16,9 +18,11 @@ please file an issue!
 
 extern crate byteorder;
 extern crate clear_on_drop;
-extern crate core;
 extern crate keccak;
 extern crate rand_core;
+
+#[cfg(feature = "std")]
+extern crate core;
 
 #[cfg(test)]
 extern crate curve25519_dalek;

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -1,7 +1,8 @@
 //! Minimal implementation of (parts of) Strobe.
 
+use core::ops::{Deref, DerefMut};
+
 use keccak;
-use ::core::ops::{Deref, DerefMut};
 
 /// Strobe R value; security level 128 is hardcoded
 const STROBE_R: u8 = 166;

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -1,7 +1,7 @@
 //! Minimal implementation of (parts of) Strobe.
 
 use keccak;
-use std::ops::{Deref, DerefMut};
+use ::core::ops::{Deref, DerefMut};
 
 /// Strobe R value; security level 128 is hardcoded
 const STROBE_R: u8 = 166;


### PR DESCRIPTION
Note that this requires using the "nightly" feature of `clear_on_drop` to avoid erroneous attempts to try to call an executable with the target architecture triple, cf. https://github.com/cesarb/clear_on_drop/issues/20