### PR TITLE
Allow Transcript::new labels to come from non-rust code without leakage, UB, etc.

### DIFF
--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -65,7 +65,7 @@ impl Transcript {
     /// **not by the proof implementation**.  See the [Passing
     /// Transcripts](https://merlin.cool/use/passing.html) section of
     /// the Merlin website for more details on why.
-    pub fn new(label: &'static [u8]) -> Transcript {
+    pub fn new(label: &[u8]) -> Transcript {
         use constants::MERLIN_PROTOCOL_LABEL;
 
         #[cfg(feature = "debug-transcript")]


### PR DESCRIPTION
Merlin requires `'static` protocol labels, which normally originate in Rust code for various reasons, ala session type.  Yet, the label passwd to `Transcript::new` could reasonably originate outside Rust code when protocols are designed to be composed.

https://github.com/paritytech/schnorrkel-js/issues/12#issuecomment-507547778