### PR TITLE
Move to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "merlin"
 version = "1.1.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>",
            "isis agora lovecruft <isis@patternsinthevoid.net>"]
+edition = "2018"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/dalek-cryptography/merlin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,25 +15,6 @@ please file an issue!
 "#
 );
 
-extern crate byteorder;
-extern crate clear_on_drop;
-extern crate keccak;
-extern crate rand_core;
-
-#[cfg(feature = "std")]
-extern crate core;
-
-#[cfg(test)]
-extern crate curve25519_dalek;
-#[cfg(feature = "hex")]
-extern crate hex;
-#[cfg(test)]
-extern crate rand;
-#[cfg(test)]
-extern crate rand_chacha;
-#[cfg(test)]
-extern crate strobe_rs;
-
 mod constants;
 mod strobe;
 mod transcript;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,6 @@ mod constants;
 mod strobe;
 mod transcript;
 
-pub use transcript::Transcript;
-pub use transcript::TranscriptRng;
-pub use transcript::TranscriptRngBuilder;
+pub use crate::transcript::Transcript;
+pub use crate::transcript::TranscriptRng;
+pub use crate::transcript::TranscriptRngBuilder;

--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -36,7 +36,7 @@ pub struct Strobe128 {
 }
 
 impl ::core::fmt::Debug for Strobe128 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         // Ensure that the Strobe state isn't accidentally logged
         write!(f, "Strobe128: STATE OMITTED")
     }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,6 +1,6 @@
 use rand_core;
 
-use strobe::Strobe128;
+use crate::strobe::Strobe128;
 
 fn encode_u64(x: u64) -> [u8; 8] {
     use byteorder::{ByteOrder, LittleEndian};
@@ -66,7 +66,7 @@ impl Transcript {
     /// Transcripts](https://merlin.cool/use/passing.html) section of
     /// the Merlin website for more details on why.
     pub fn new(label: &'static [u8]) -> Transcript {
-        use constants::MERLIN_PROTOCOL_LABEL;
+        use crate::constants::MERLIN_PROTOCOL_LABEL;
 
         #[cfg(feature = "debug-transcript")]
         {
@@ -391,7 +391,7 @@ mod tests {
     impl TestTranscript {
         /// Strobe init; meta-AD(label)
         pub fn new(label: &[u8]) -> TestTranscript {
-            use constants::MERLIN_PROTOCOL_LABEL;
+            use crate::constants::MERLIN_PROTOCOL_LABEL;
 
             let mut tt = TestTranscript {
                 state: Strobe::new(MERLIN_PROTOCOL_LABEL.to_vec(), SecParam::B128),


### PR DESCRIPTION
I thought I'd help in migrating a bit. Was easier than I thought, since there were no weird things happening in the crate.