### PR TITLE
Add external RNG input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ features = ["nightly"]
 keccak = { version = "0.1.0", default-features = false }
 byteorder = { version = "1.2.4", default-features = false }
 clear_on_drop = { version = "0.2.3", default-features = false }
-rand_core = { version = "0.4", default-features = false }
+rand_core = { version = "0.3", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
-[dev-dependencies]
-strobe-rs = "0.3"
-curve25519-dalek = "1"
-rand_chacha = "0.1"
-rand = "0.6"
+# [dev-dependencies]
+# strobe-rs = "0.3"
+# curve25519-dalek = "1"
+# rand_chacha = "0.1"
+# rand = "0.6" 
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ hex = {version = "0.3", default-features = false, optional = true}
 strobe-rs = "0.3"
 curve25519-dalek = "1"
 rand_chacha = "0.1"
-rand = "0.6" 
+rand = "0.6"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ features = ["nightly"]
 keccak = { version = "0.1.0", default-features = false }
 byteorder = { version = "1.2.4", default-features = false }
 clear_on_drop = { version = "0.2.3", default-features = false }
-rand_core = { version = "0.3", default-features = false }
+rand_core = { version = "0.4", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
-# [dev-dependencies]
-# strobe-rs = "0.3"
-# curve25519-dalek = "1"
-# rand_chacha = "0.1"
-# rand = "0.6" 
+[dev-dependencies]
+strobe-rs = "0.3"
+curve25519-dalek = "1"
+rand_chacha = "0.1"
+rand = "0.6" 
 
 [features]
 default = ["std"]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -336,6 +336,18 @@ impl TranscriptRngBuilder {
             strobe: self.strobe,
         }
     }
+    pub fn finalize_trng(mut self,trng: &[u8]) -> TranscriptRng
+    {
+        let mut random_bytes = [0u8; 32];
+        random_bytes.copy_from_slice(&trng[..]);
+
+        self.strobe.meta_ad(b"rng", false);
+        self.strobe.key(&random_bytes, false);
+
+        TranscriptRng {
+            strobe: self.strobe,
+        }
+    }
 }
 
 /// An RNG providing synthetic randomness to the prover.


### PR DESCRIPTION
## External RNG
We are working on porting w3f/schnorrkel to embedded device. Merlin is one of its dependency. Embedded device always has hardware random source which is from physical noise, very secure. Meanwhile, some functions like thread_rng in rand or rand_core could not be compiled in no_std environment on thzumbv7m-none-eabi or similar. So we added a function with extra para to make it is possible to use external RNG in transcript.rs
```rust
pub fn finalize_trng(mut self,trng: &[u8]) -> TranscriptRng
    {
        let mut random_bytes = [0u8; 32];
        random_bytes.copy_from_slice(&trng[..]);

        self.strobe.meta_ad(b"rng", false);
        self.strobe.key(&random_bytes, false);

        TranscriptRng {
            strobe: self.strobe,
        }
    }
```
To see how the embedded porting works, you could ref [wookong-dot-schnorrkel](https://github.com/wookong-dot/schnorrkel)