### PR TITLE
Add a guide to contributing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+We welcome code and documentation PRs.  It's probably best to start by
+opening or commenting on an existing issue, since the code is in a state
+of flux.
+
+# Workflow
+
+## Branches
+
+Currently, the work on the `merlin` crate is in two branches:
+
+* `main` holds the latest released version;
+
+* `develop` holds ongoing development work.
+
+Pull requests should be made against `develop`, **not** `main`.
+
+It's best to start a PR for every in-progress branch so that it's possible
+to track all ongoing development work.  Adding the `PTAL` (please take a 
+look) label indicates that the branch is ready for code review.
+
+## Labels
+
+Labels starting with `T-` are for labeling topics (`T-api`, `T-r1cs`, etc).
+
+The `T-research` label indicates unsolved open problems.
+
+Labels starting with `P-` are for priority levels.
+
+Labels starting with `E-` are for effort estimates.
+
+## CI
+
+We enforce style in CI using `cargo fmt`.
+
+The `merlin` repo currently pins a Rust nightly.  This means that
+all `cargo` invocations made inside of the `merlin` repo use the
+pinned nightly version.  This means that running `cargo fmt` in the
+`merlin` repo requires that `rustfmt` is installed *for the pinned
+nightly toolchain*.  To do this, run
+```
+rustup component add rustfmt-preview
+```
+while in the `merlin` repo.
+
+To run `rustfmt`, use
+```
+cargo fmt
+```


### PR DESCRIPTION
I noticed that another PR in this repository was made against the master branch. Since the merlin repo has a "master" and "develop" branch, in the same way as other crates in the dalek project, I assume that the intention is that PRs should similarly be made against the "develop" branch.

I copied the existing contributing guide from bulletproofs to make that workflow clear to contributors.