### PR TITLE
Fix broken CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     script:
       - cargo nono check --no-default-features --features nightly
     install:
-      - cargo install --force cargo-nono || true
+      - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git hobofan/cargo-nono
 
 notifications:
   slack:


### PR DESCRIPTION
Currently, the CI is broken because cargo-nono fails to compile. The developers of the project recommend using pre-built binaries for CI, rather than installing from crates.io, in their project's README:

https://github.com/hobofan/cargo-nono

I was able to replicate the compile failure in a Ubuntu 18 VM. After installing the pre-built binaries, I was able to run the check `cargo nono check --no-default-features --features nightly` successfully.