### PR TITLE
Fix failing CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     script:
     - cargo test
     - cargo fmt --all -- --check
-  # Test if crate can be truly built without std, cargo-nono 0.1.5 now works against clear_on_drop and has been released
-  - rust: nightly
-    script:
-      - cargo nono check --no-default-features --features nightly
-    install:
-      - cargo install --force cargo-nono || true
 
 notifications:
   slack:


### PR DESCRIPTION
A previous PR added a third-party tool, `cargo nono`, in an attempt to
check whether the crate would be `no_std` compatible.  Because of issues
with the `no_std` ecosystem, this is nontrivial to check.

For instance, build-dependencies and dependencies have unified feature
selection (https://github.com/rust-lang/cargo/issues/4866), so a build-
or dev- dependency of the crate may enable a `std` feature in a
transitive dependency.  This means that to *actually* test `no_std`
compatibility, what must be tested is the *final `no_std` executable*,
*not* its dependencies, and any errors in dependencies need to be traced
back from the final executable.

As a workaround, various third-party tools (like `cargo nono`) exist,
but the tool failed to build and broke CI.  As these tools are not as
well-maintained as the core Rust infrastructure, this commit removes
them entirely to reduce maintenance burden in this crate.  `no_std`
users should check `no_std` compatibility in their crates.