### PR TITLE
Update rand_core to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,13 @@ features = ["nightly"]
 keccak = { version = "0.1.0", default-features = false }
 byteorder = { version = "1.2.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-rand_core = { version = "0.4", default-features = false }
+rand_core = { version = "0.5", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.5"
-curve25519-dalek = "1"
-rand_chacha = "0.1"
-rand = "0.6"
+curve25519-dalek = "2"
+rand_chacha = "0.2"
 
 [features]
 default = ["std"]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -233,7 +233,7 @@ impl Transcript {
 /// [`Transcript`] to an owned [`TranscriptRng`] as follows:
 /// ```
 /// # extern crate merlin;
-/// # extern crate rand;
+/// # extern crate rand_core;
 /// # use merlin::Transcript;
 /// # fn main() {
 /// # let mut transcript = Transcript::new(b"TranscriptRng doctest");
@@ -246,7 +246,7 @@ impl Transcript {
 ///     .build_rng()
 ///     .rekey_with_witness_bytes(b"witness1", witness_data)
 ///     .rekey_with_witness_bytes(b"witness2", more_witness_data)
-///     .finalize(&mut rand::thread_rng());
+///     .finalize(&mut rand_core::OsRng);
 /// # }
 /// ```
 /// In this example, the final `rng` is a PRF of `public_data`
@@ -477,8 +477,8 @@ mod tests {
     #[test]
     fn transcript_rng_is_bound_to_transcript_and_witnesses() {
         use curve25519_dalek::scalar::Scalar;
-        use rand::SeedableRng;
         use rand_chacha::ChaChaRng;
+        use rand_core::SeedableRng;
 
         // Check that the TranscriptRng is bound to the transcript and
         // the witnesses.  This is done by producing a sequence of


### PR DESCRIPTION
This will become a `2.0` release; doing this after #56 means that users of the 1.x series will be transparently upgraded from `clear_on_drop` without having to maintain a backport branch.