### PR TITLE
GH action testing merlin on PowerPC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+name: Test merlin
+
+on:
+  push:
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  native-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_toolchain: [nightly, stable]
+        os: [ubuntu-latest]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust ${{ matrix.rust_toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.rust_toolchain }}
+            profile: minimal
+            default: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  cross-linux-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_target:
+          - powerpc-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            profile: minimal
+            target: ${{ matrix.rust_target }}
+            default: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          # see https://github.com/rust-embedded/cross
+          use-cross: true
+          command: build
+          args: --target ${{ matrix.rust_target }}
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target ${{ matrix.rust_target }} -- --test-threads=1


### PR DESCRIPTION
Addresses #58

This voluntarily does not change the compilation error in `src/lib.rs` — I'm more than happy to add a commit that does so given guidance on how to proceed.

Please look at https://github.com/huitseeker/merlin/actions/runs/95327077 to witness a run (with the expected failures on powerpc, see above re: not removing the compile error) on my fork.
