### PR TITLE
Remove big endian compile error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,15 +6,6 @@
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
-#[cfg(target_endian = "big")]
-compile_error!(
-    r#"
-This crate doesn't support big-endian targets, since I didn't
-have one to test correctness on.  If you're seeing this message,
-please file an issue!
-"#
-);
-
 mod constants;
 mod strobe;
 mod transcript;


### PR DESCRIPTION
Fixes #58. The transcript bytes appear to always be written in little endian, even on big endian systems, due to the byteorder encoding wrapper functions, but we should probably update the github action from #59 that tests on powerPC to use the `debug-transcript` feature to check that.