### PR TITLE
Flag to enable &[u8] labels instead of &'static[u8].

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,34 +31,35 @@ jobs:
         with:
           command: test
 
-  cross-linux-test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust_target:
-          - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            profile: minimal
-            target: ${{ matrix.rust_target }}
-            default: true
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          # see https://github.com/rust-embedded/cross
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.rust_target }}
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target ${{ matrix.rust_target }} -- --test-threads=1
+  # Uncomment this when adding support for big-endian targets.
+  # cross-linux-test:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       rust_target:
+  #         - powerpc-unknown-linux-gnu
+  #         - powerpc64-unknown-linux-gnu
+  #   timeout-minutes: 10
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Rust nightly
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #           toolchain: nightly
+  #           profile: minimal
+  #           target: ${{ matrix.rust_target }}
+  #           default: true
+  #     - name: Build
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         # see https://github.com/rust-embedded/cross
+  #         use-cross: true
+  #         command: build
+  #         args: --target ${{ matrix.rust_target }}
+  #     - name: Test
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         use-cross: true
+  #         command: test
+  #         args: --target ${{ matrix.rust_target }} -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0
+
+* Update `rand_core` to `0.6`.  Because traits from `rand_core` are part of the
+  public API, this is technically a breaking change, but there are no other
+  changes to Merlin's API.
+
 ## 2.0.1
 
 * Update repository, add `html_root_url`, update dev-dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* Update repository, add `html_root_url`, update dev-dependencies.
+
 ## 2.0.0
 
 * Update `rand_core` to `0.5`.  Because traits from `rand_core` are part of the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "merlin"
-version = "2.0.0"
+# Before incrementing:
+# - update CHANGELOG
+# - update html_root_url
+# - update README if required by semver
+version = "2.0.1"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
 edition = "2018"
 readme = "README.md"
 license = "MIT"
-repository = "https://github.com/dalek-cryptography/merlin"
+repository = "https://github.com/zkcrypto/merlin"
 homepage = "https://docs.rs/merlin"
 documentation = "https://docs.rs/merlin"
 categories = ["cryptography"]
@@ -26,7 +30,7 @@ hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.5"
-curve25519-dalek = "2"
+curve25519-dalek = { version = "3", package = "curve25519-dalek-ng" }
 rand_chacha = "0.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "merlin"
 # - update CHANGELOG
 # - update html_root_url
 # - update README if required by semver
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>"]
 edition = "2018"
 readme = "README.md"
@@ -25,13 +25,13 @@ features = ["nightly"]
 keccak = { version = "0.1.0", default-features = false }
 byteorder = { version = "1.2.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.5"
-curve25519-dalek = { version = "3", package = "curve25519-dalek-ng" }
-rand_chacha = "0.2"
+curve25519-dalek = { version = "4", package = "curve25519-dalek-ng" }
+rand_chacha = "0.3"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ default = ["std"]
 nightly = []
 debug-transcript = ["hex"]
 std = ["rand_core/std", "byteorder/std"]
+# Accept `&[u8]` labels instead of the default `&'static [u8]`.
+dynamic-labels = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![doc(html_root_url = "https://docs.rs/merlin/2.0.1")]
+#![doc(html_root_url = "https://docs.rs/merlin/3.0.0")]
 // put this after the #![doc(..)] so it appears as a footer:
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
+#![doc(html_root_url = "https://docs.rs/merlin/2.0.1")]
 // put this after the #![doc(..)] so it appears as a footer:
 //! Note that docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -66,7 +66,10 @@ impl Transcript {
     /// **not by the proof implementation**.  See the [Passing
     /// Transcripts](https://merlin.cool/use/passing.html) section of
     /// the Merlin website for more details on why.
-    pub fn new(label: &'static [u8]) -> Transcript {
+    pub fn new(
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+    ) -> Transcript {
         use crate::constants::MERLIN_PROTOCOL_LABEL;
 
         #[cfg(feature = "debug-transcript")]
@@ -93,7 +96,12 @@ impl Transcript {
     /// also appended to the transcript.  See the [Transcript
     /// Protocols](https://merlin.cool/use/protocol.html) section of
     /// the Merlin website for details on labels.
-    pub fn append_message(&mut self, label: &'static [u8], message: &[u8]) {
+    pub fn append_message(
+        &mut self,
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+        message: &[u8],
+    ) {
         let data_len = encode_usize_as_u32(message.len());
         self.strobe.meta_ad(label, false);
         self.strobe.meta_ad(&data_len, true);
@@ -137,7 +145,12 @@ impl Transcript {
     /// This is intended to avoid any possible confusion between the
     /// transcript-level messages and protocol-level commitments.
     #[deprecated(since = "1.1.0", note = "renamed to append_message for clarity.")]
-    pub fn commit_bytes(&mut self, label: &'static [u8], message: &[u8]) {
+    pub fn commit_bytes(
+        &mut self,
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+        message: &[u8],
+    ) {
         self.append_message(label, message);
     }
 
@@ -152,7 +165,12 @@ impl Transcript {
     ///
     /// Calls `append_message` with the 8-byte little-endian encoding
     /// of `x`.
-    pub fn append_u64(&mut self, label: &'static [u8], x: u64) {
+    pub fn append_u64(
+        &mut self,
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+        x: u64,
+    ) {
         self.append_message(label, &encode_u64(x));
     }
 
@@ -162,7 +180,12 @@ impl Transcript {
     /// This is intended to avoid any possible confusion between the
     /// transcript-level messages and protocol-level commitments.
     #[deprecated(since = "1.1.0", note = "renamed to append_u64 for clarity.")]
-    pub fn commit_u64(&mut self, label: &'static [u8], x: u64) {
+    pub fn commit_u64(
+        &mut self,
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+        x: u64,
+    ) {
         self.append_u64(label, x);
     }
 
@@ -172,7 +195,12 @@ impl Transcript {
     /// also appended to the transcript.  See the [Transcript
     /// Protocols](https://merlin.cool/use/protocol.html) section of
     /// the Merlin website for details on labels.
-    pub fn challenge_bytes(&mut self, label: &'static [u8], dest: &mut [u8]) {
+    pub fn challenge_bytes(
+        &mut self,
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
+        dest: &mut [u8],
+    ) {
         let data_len = encode_usize_as_u32(dest.len());
         self.strobe.meta_ad(label, false);
         self.strobe.meta_ad(&data_len, true);
@@ -288,7 +316,8 @@ impl TranscriptRngBuilder {
     /// The `label` parameter is metadata about `witness`.
     pub fn rekey_with_witness_bytes(
         mut self,
-        label: &'static [u8],
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
         witness: &[u8],
     ) -> TranscriptRngBuilder {
         let witness_len = encode_usize_as_u32(witness.len());
@@ -310,7 +339,8 @@ impl TranscriptRngBuilder {
     )]
     pub fn commit_witness_bytes(
         self,
-        label: &'static [u8],
+        #[cfg(not(feature = "dynamic-labels"))] label: &'static [u8],
+        #[cfg(feature = "dynamic-labels")] label: &[u8],
         witness: &[u8],
     ) -> TranscriptRngBuilder {
         self.rekey_with_witness_bytes(label, witness)


### PR DESCRIPTION
In Flame, I want to expose raw Transcript API (create, write, read) to smart contract code, so the labels cannot be `'static` — they are supposed to be statically baked into contract code, but from the VM point of view that'd be a dynamically allocated string. This PR introduces a feature flag to relax the `'static` requirement, but IMHO it could be relaxed outright without a feature flag. Meanwhile I'm using the fork with that flag in my code.

@hdevalence wdyt?